### PR TITLE
Fix a reference entry in hologo's documentation

### DIFF
--- a/hologo.dtx
+++ b/hologo.dtx
@@ -4943,14 +4943,14 @@ $ #1{\string ^^^^0395}{\string ^^^^03b5}%
 % \url{http://www.extex.org/documentation/faq.html}
 %
 % \bibitem{LyX}
-% %@MISC{ LyX,
-% %  title = {{LyX 2.0.0 -- The Document Processor [Computer software and manual]}},
-% %  author = {{The LyX Team}},
-% %  howpublished = {Internet: http://www.lyx.org},
-% %  year = {2011-05-08},
-% %  note = {Retrieved May 10, 2011, from http://www.lyx.org},
-% %  url = {http://www.lyx.org/}
-% %}
+% ^^A@MISC{ LyX,
+% ^^A  title = {{LyX 2.0.0 -- The Document Processor [Computer software and manual]}},
+% ^^A  author = {{The LyX Team}},
+% ^^A  howpublished = {Internet: http://www.lyx.org},
+% ^^A  year = {2011-05-08},
+% ^^A  note = {Retrieved May 10, 2011, from http://www.lyx.org},
+% ^^A  url = {http://www.lyx.org/}
+% ^^A}
 % The \hologo{LyX} Team,
 % \textit{\hologo{LyX} -- The Document Processor},
 % 2011-05-08.\\


### PR DESCRIPTION
I happened to see a weird reference entry caused by the change in `%`'s category code:

> @MISC LyX, title = LyX 2.0.0 &ndash; The Document Processor [Computer
software and manual], author = The LyX Team, howpublished = Internet:
http://www.lyx.org, year = 2011-05-08, note = Retrieved May 10, 2011, from
http://www.lyx.org, url = http://www.lyx.org/ The LyX Team, _LyX &ndash; The
Document Processor_, 2011-05-08.  
> http://www.lyx.org/

I just replaced the`%`s with `^^A`, but these lines can safely be removed IMHO. I will make an additional commit that deletes the `@MISC{...}` part if it's OK for you.