### PR TITLE
[bookmark] fix typo in doc

### DIFF
--- a/bookmark.dtx
+++ b/bookmark.dtx
@@ -307,9 +307,9 @@ and the derived files
 % and \hologo{VTeX} are automatically detected.
 % The default for the DVI drivers is \xoption{dvips}. This can
 % be changed in the configuration file \xfile{bookmark.cfg} by
-% \cs{BookmarkDefaultDriver}, e.g.:
+% \cs{BookmarkDriverDefault}, e.g.:
 % \begin{quote}
-% |\def\BookmarkDefaultDriver{dvipdfm}|
+% |\def\BookmarkDriverDefault{dvipdfm}|
 % \end{quote}
 %
 % \paragraph{Open bookmarks with dvipdfmx.} Since 2007-04-25 the


### PR DESCRIPTION
In sty code, the name `\BookmarkDriverDefault` is used. However in user doc, the different name `\BookmarkDefaultDriver` is mentioned. This commit unifies the naming to the one used in sty code.

Current usage in sty code:
https://github.com/ho-tex/oberdiek/blob/a8cc029c77d5e6a48fe5bf95989a8ef3c3f475ab/bookmark.dtx#L1678-L1705
