### PR TITLE
A hack for PDF/A-3 compliance

### DIFF
--- a/embedfile.dtx
+++ b/embedfile.dtx
@@ -904,6 +904,11 @@ You need Acrobat Reader 8 or higher.
 \EmFi@temp{desc}
 %    \end{macrocode}
 %    \end{macro}
+%    \begin{macro}{\EmFi@S@afrelationship}
+%    \begin{macrocode}
+\EmFi@temp{afrelationship}
+%    \end{macrocode}
+%    \end{macro}
 %    \begin{macro}{\EmFi@S@moddate}
 %    \begin{macrocode}
 \EmFi@temp{moddate}
@@ -1028,6 +1033,10 @@ You need Acrobat Reader 8 or higher.
 %    Description (optional).
 %    \begin{macrocode}
 \EmFi@DefineKey{desc}{}
+%    \end{macrocode}
+%    AFRelationship (mandatory for PDF/A-3 compliance).
+%    \begin{macrocode}
+\EmFi@DefineKey{afrelationship}{}
 %    \end{macrocode}
 %    Method for converting text to PDF strings.
 %    \begin{macrocode}
@@ -1190,6 +1199,7 @@ You need Acrobat Reader 8 or higher.
             \else\ifx\EmFi@type\EmFi@S@number N%
             \else\ifx\EmFi@type\EmFi@S@file F%
             \else\ifx\EmFi@type\EmFi@S@desc Desc%
+            \else\ifx\EmFi@type\EmFi@S@afrelationship AFRelationship%
             \else\ifx\EmFi@type\EmFi@S@moddate ModDate%
             \else\ifx\EmFi@type\EmFi@S@creationdate CreationDate%
             \else\ifx\EmFi@type\EmFi@S@size Size%
@@ -1302,6 +1312,8 @@ You need Acrobat Reader 8 or higher.
     \let\EmFi@type\EmFi@temp
   \else\ifx\EmFi@temp\EmFi@S@desc
     \let\EmFi@type\EmFi@temp
+  \else\ifx\EmFi@temp\EmFi@S@afrelationship
+    \let\EmFi@type\EmFi@temp
   \else\ifx\EmFi@temp\EmFi@S@moddate
     \let\EmFi@type\EmFi@temp
   \else\ifx\EmFi@temp\EmFi@S@creationdate
@@ -1312,9 +1324,9 @@ You need Acrobat Reader 8 or higher.
     \EmFi@Error{%
       Unknown type `\EmFi@temp'.\MessageBreak
       Supported types: `text', `date', `number', `file',\MessageBreak
-      `desc', `moddate', `creationdate', `size'%
+      `desc', `afrelationship', `moddate', `creationdate', `size'%
     }%
-  \fi\fi\fi\fi\fi\fi\fi\fi
+  \fi\fi\fi\fi\fi\fi\fi\fi\fi
 }
 %    \end{macrocode}
 %    \begin{macrocode}
@@ -1414,6 +1426,11 @@ You need Acrobat Reader 8 or higher.
         \else
           \EmFi@convert\EmFi@desc\EmFi@@desc
         \fi
+        \ifx\EmFi@afrelationship\ltx@empty
+          \let\EmFi@@afrelationship\ltx@empty
+        \else
+          \EmFi@convert\EmFi@afrelationship\EmFi@@afrelationship
+        \fi
         \ifEmFi@item
           \let\do\EmFi@do
           \immediate\pdfobj{%
@@ -1451,6 +1468,10 @@ You need Acrobat Reader 8 or higher.
             \ifx\EmFi@@desc\ltx@empty
             \else
               /Desc(\EmFi@@desc)%
+            \fi
+            \ifx\EmFi@@afrelationship\ltx@empty
+            \else
+              /AFRelationship\EmFi@@afrelationship%
             \fi
             /EF<<%
               /F \the\pdflastobj\ltx@space 0 R%
@@ -1574,6 +1595,17 @@ You need Acrobat Reader 8 or higher.
         }%
         \pdfnames{%
           /EmbeddedFiles \the\pdflastobj\ltx@space 0 R%
+        }%
+      \endgroup
+      \begingroup
+        \def\do##1##2{%
+          \ltx@space##2%
+        }%
+        \immediate\pdfobj{%
+          [\EmFi@list]%
+        }%
+        \pdfcatalog{%
+          /AF \the\pdflastobj\ltx@space 0 R%
         }%
       \endgroup
 %    \end{macrocode}


### PR DESCRIPTION
- adds /AF key followed by an array of embedded objects to the Catalog
- adds /AFRelationship key followed by the appropriate arguement,
  which shall be provided by the user via the new option "afrelationship",
  which shall be one of /Data, /Source, /Alternative, /Supplement, or
  /Unspecified.

This patch relates to Issue 37. With this patch, the mentioned examples can be made to pass validation for PDF/A-3b compliance (tested with veraPDF) by adding the new "afrelationship" option.
