### PR TITLE
fix enparen doc typo

### DIFF
--- a/enparen.dtx
+++ b/enparen.dtx
@@ -294,9 +294,9 @@ and the derived files
 %\enparenLeft text before table ...
 %\begin{table}
 %  \caption{Table caption}
-%  \enparenBegin{Context}{table}
+%  \enparenBeginContext{table}
 %  Other text \enparen{foobar}.
-%  \enparenEnd{Context}{table}
+%  \enparenEndContext{table}
 %\end{table}
 %text after table ...
 %\enparenRight


### PR DESCRIPTION
Fixes `\enparenBegin{Context}` -> `\enparenBeginContext` and similarly for `\enparenEnd...`