### PR TITLE
use baz instead of bar in aliascnt example

### DIFF
--- a/aliascnt.dtx
+++ b/aliascnt.dtx
@@ -229,9 +229,9 @@ and the derived files
 %    \begin{quote}
 %\begin{verbatim}
 %\newtheorem{foo}{Foo}% counter "foo"
-%\newaliascnt{bar}{foo}% alias counter "bar"
-%\newtheorem{bar}[bar]{Bar}
-%\aliascntresetthe{bar}
+%\newaliascnt{baz}{foo}% alias counter "baz"
+%\newtheorem{baz}[baz]{Baz}
+%\aliascntresetthe{baz}
 %\end{verbatim}
 %    \end{quote}
 % \end{desc}


### PR DESCRIPTION
The current aliascnt example with `\newtheorem` does `\newtheorem{bar}...` which errors since `\bar` is already defined. Obviously this is just a toy example, but it would be nice if it worked if just copied and pasted. This replaces `bar` with `baz`.